### PR TITLE
Use default release please action command

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           release-type: node
           package-name: ${{env.ACTION_NAME}}
-          command: github-release
       - uses: actions/checkout@v2
       - name: tag major and patch versions
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Remove `command: github-release` in order for the `release-please` action to create a release PR