### PR TITLE
fix: No PR description exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,12 @@ async function main() {
     return 1;
   }
 
-  const { body } = data;
+  let { body } = data;
+
+  if (!body) {
+    core.info('Pull request has no description, setting it to an empty string');
+    body = '';
+  }
 
   if (body.includes(url)) {
     core.info('Decription already includes deployed url');


### PR DESCRIPTION
If a PR does not have any description, the body returned is null. This blows up `body.includes(url)` condition.
Setting body as an empty string to cover the above scenario.

![image](https://user-images.githubusercontent.com/10942392/146244299-3880956a-f660-4da3-9a54-7508d6ecaceb.png)
