### PR TITLE
Upgrade to Node 16 and make action slightly more generic

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           release-type: node
           package-name: ${{env.ACTION_NAME}}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: tag major and patch versions
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
     required: false
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Append Github PR description"
-description: "Append the provided deployment URL to Github pull request description"
+description: "Append the provided URL to Github pull request description"
 branding:
   icon: "align-left"
   color: "blue"
@@ -17,10 +17,10 @@ inputs:
     description: "The pr number"
     required: true
   url:
-    description: "The output deployed url"
+    description: "The output url"
     required: true
   message:
-    description: "The output deployed message (optional)"
+    description: "The output message (optional)"
     required: false
 
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,7 +45,7 @@ async function main() {
   }
 
   if (body.includes(url)) {
-    core.info('Decription already includes deployed url');
+    core.info('Decription already includes URL provided');
     return 0;
   }
 


### PR DESCRIPTION
- Upgrade Checkout to v3
  - GitHub is deprecating Node 12
- Upgrade to Node 16
  - GitHub is deprecating Node 12
- Make action slightly more generic
  - Allows for more use cases, like appending a ticket number to a PR

Fixes #8 