### PR TITLE
Upgrade to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
     required: false
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function main() {
   }
 
   if (body.includes(url)) {
-    core.info('Decription already includes deployed url');
+    core.info('Description already includes deployed url');
     return 0;
   }
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/chabroA/action-append-pr-description",
   "dependencies": {
-    "@actions/core": "^1.2.6",
-    "@actions/github": "^4.0.0"
+    "@actions/core": "^1.10.1",
+    "@actions/github": "^6.0.0"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.27.0"


### PR DESCRIPTION
Node 16 actions are deprecated.

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.